### PR TITLE
_syncLocalが初期化されてしまった場合に正しく復帰するように修正

### DIFF
--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.asset
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: ManualObjectSync
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: 50ab936bebe4d784d97985edb6f2747e,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: daa91e1af9026a342a2622f90a756628,
     type: 2}
   udonAssembly: 
   assemblyError: 

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
@@ -209,6 +209,14 @@ namespace MimyLab
             }
         }
 
+        public override void OnPreSerialization()
+        {
+            if (_syncScale != _transform.localScale)
+            {
+                _syncScale = transform.localScale;
+            }
+        }
+
         public override void OnDeserialization()
         {
             Initialize();


### PR DESCRIPTION
【現象】

* ManualObjectSyncで同期しているオブジェクトのlocalScaleが(0,0,0)に上書きされてしまうことがある

【原因】

[こちらのツイート](https://twitter.com/3405691582/status/1489570191419662338)でも言及されているとおり、Owner委譲時にUdonSyncedの値が初期値（Vector3.Zero）に戻ることがあるみたいです。実際にManualObjectSyncを使ってこの現象が発生するか試しましたが、localScaleがゼロになってしまう現象が起きました。

![image](https://user-images.githubusercontent.com/861868/215466131-daee85fa-7fc6-43c6-b8f4-c1a91e7710d1.png)
![image](https://user-images.githubusercontent.com/861868/215466144-9a88bd79-878b-4b05-8079-96f3527048f2.png)

1行目がOwner情報、2行目がPosition、3行目がlocalScaleの値です。所有権が他人に移ったタイミングで、一瞬だけUdonSyncedValueが初期化された状態でOnDeserializeが発火するみたいです。

【対策】

実際の`localScale`の値と`_syncScale` の値がズレていたとしてもOwner側でそれを補正する処理がなかったので、`OnPreSerialization()`を定義してそこで値を補正するようにしました。

