### PR TITLE
Add EditorUtility.SetDirty

### DIFF
--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSUpdateManager.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSUpdateManager.cs
@@ -25,6 +25,23 @@ namespace MimyLab
         private ManualObjectSync[] _mosList = new ManualObjectSync[0];
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR        
+
+        [InitializeOnLoadMethod]
+        private static void OnPlayModeStateChanged()
+        {
+            EditorApplication.playModeStateChanged += state =>
+            {
+                if (state == PlayModeStateChange.EnteredEditMode)
+                {
+                    var tmpMosUpdateManagerList = FindObjectsOfType<MOSUpdateManager>();
+                    foreach (var tmpMosUpdateManager in tmpMosUpdateManagerList)
+                    {
+                        tmpMosUpdateManager.SetupAllMOS();
+                    }
+                }
+            };
+        }
+
         private void Reset()
         {
             SetupAllMOS();
@@ -50,6 +67,7 @@ namespace MimyLab
                 {
                     tmp_mos.updateManager = this;
                     tmp_mos.respawnHightY = respawnHightY;
+                    EditorUtility.SetDirty(tmp_mos);
                 }
             }
         }

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
@@ -188,7 +188,11 @@ namespace MimyLab
             if (PrefabUtility.IsPartOfPrefabAsset(this.gameObject)) { return; }
 
             if (updateManager) { return; }
-            if (updateManager = FindObjectOfType<MOSUpdateManager>()) { return; }
+            if (updateManager = FindObjectOfType<MOSUpdateManager>())
+            {
+                EditorUtility.SetDirty(gameObject);
+                return;
+            }
 
             var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(_UpdateManagerPrefabGUID));
             if (!prefab)


### PR DESCRIPTION
`ManualObjectSync` が実行時に `MOSUpdateManager` を失ってしまう件ですが、おそらくEditor拡張で設定した後にオブジェクトにダーティフラグを立てていないため、実行時に設定が巻き戻っているのが原因でないかと推測します。

* `MOSUpdateManager`の初期化時に`EditorUtility.SetDirty`を実行する
* `Reset()` タイミングだけではカバーしきれないため、Editモードに切り替わったタイミングで再度セットする

という処理を追加しました。
ひとまず私の環境ではこれで安定しました。