### PR TITLE
chore: move using into namespace block to avoid namespace-classname conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Mm]emoryCaptures/
-/[Aa]ssets/
+/[Aa]ssets/*
 
 # Asset meta data should only be ignored when the corresponding asset is also ignored
 !/[Aa]ssets/**/*.meta
@@ -63,3 +63,7 @@ crashlytics-build.properties
 Assets/PackageMakerWindowData.asset*
 .idea
 .vscode
+
+# for CE in U# environment
+!/Assets/UtilitiesNamspace.cs
+!/Assets/UtilitiesNamspace.cs.meta

--- a/Assets/UtilitiesNamspace.cs
+++ b/Assets/UtilitiesNamspace.cs
@@ -1,0 +1,6 @@
+namespace Utilities
+{
+    public class TestClass
+    {
+    }
+}

--- a/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToAnimator.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToAnimator.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
     public enum ActiveRelayToAnimatorEventType
     {
         Active,

--- a/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToComponent.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToComponent.cs
@@ -4,17 +4,17 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using UnityEngine.Animations;
-//using UnityEngine.UI;
-//using TMPro;
-//using VRC.SDKBase;
-//using VRC.SDK3.Components;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using UnityEngine.Animations;
+    //using UnityEngine.UI;
+    //using TMPro;
+    //using VRC.SDKBase;
+    //using VRC.SDK3.Components;
+    //using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Active Relay/To Component")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
     public class ActiveRelayToComponent : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToEffect.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToEffect.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Active Relay/To Effect")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
     public class ActiveRelayToEffect : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToUdonBehaviour.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ActiveRelay/Scripts/ActiveRelayToUdonBehaviour.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Active Relay/To UdonBehaviour")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
     public class ActiveRelayToUdonBehaviour : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/AdvancedWorldSettings/Scripts/AdvancedWorldSettings.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/AdvancedWorldSettings/Scripts/AdvancedWorldSettings.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [System.Flags]
     public enum AdvancedWorldSettingsInitializeEyeHeightType
     {

--- a/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/DustBox.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/DustBox.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.SDK3.Components;
-using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.SDK3.Components;
+    using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/GameObject Celler/Dust Box")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class DustBox : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/ObjectPoolController.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/ObjectPoolController.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
     public enum ObjectPoolControllerSwitchType
     {
         Spawn,

--- a/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/ObjectPoolManager.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/ObjectPoolManager.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-using VRC.SDK3.Components;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    using VRC.SDK3.Components;
+    //using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/GameObject Celler/ObjectPool Manager")]
     [RequireComponent(typeof(VRCObjectPool))]
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]

--- a/Packages/com.mimylab.fukuroudon/Runtime/GrabSlideDoor/Scripts/LimitedLookConstraint.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GrabSlideDoor/Scripts/LimitedLookConstraint.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Limited Constraint/LookAt")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class LimitedLookConstraint : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/GrabSlideDoor/Scripts/LimitedPositionConstraint.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GrabSlideDoor/Scripts/LimitedPositionConstraint.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Limited Constraint/Position")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class LimitedPositionConstraint : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/GrabSlideDoor/Scripts/PickupHandle.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GrabSlideDoor/Scripts/PickupHandle.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.SDK3.Components;
-using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.SDK3.Components;
+    using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Pickup Handle")]
     [RequireComponent(typeof(VRCPickup))]
     public class PickupHandle : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/InputFlyingSystem/Scripts/InputFlyingSystem.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/InputFlyingSystem/Scripts/InputFlyingSystem.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-using VRC.Udon.Common;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+    using VRC.Udon.Common;
+
     [AddComponentMenu("Fukuro Udon/Input Flying System")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class InputFlyingSystem : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/EquipWithMOS.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/EquipWithMOS.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/Manual ObjectSync/Equip with MOS")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]
     public class EquipWithMOS : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSAttacher.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSAttacher.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/Manual ObjectSync/MOS Attacher")]
     [RequireComponent(typeof(Collider))]
     [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSSceneObserver.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSSceneObserver.cs
@@ -4,16 +4,16 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UnityEngine;
-using VRC.SDK3.Components;
-
-#if UNITY_EDITOR
-using UnityEditor;
-using UnityEditor.Experimental.SceneManagement;
-#endif
-
 namespace MimyLab
 {
+    using UnityEngine;
+    using VRC.SDK3.Components;
+
+    #if UNITY_EDITOR
+    using UnityEditor;
+    using UnityEditor.Experimental.SceneManagement;
+    #endif
+
     [ExecuteAlways]
     public class MOSSceneObserver : MonoBehaviour
     {

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSUpdateManager.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/MOSUpdateManager.cs
@@ -4,18 +4,18 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
-#if UNITY_EDITOR
-using UnityEditor;
-using UnityEditor.Experimental.SceneManagement;
-#endif
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
+    #if UNITY_EDITOR
+    using UnityEditor;
+    using UnityEditor.Experimental.SceneManagement;
+    #endif
+
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class MOSUpdateManager : UdonSharpBehaviour
     {

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
@@ -4,20 +4,20 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.SDK3.Components;
-//using VRC.Udon;
-
-#if UNITY_EDITOR
-using UnityEditor;
-using UnityEditor.Experimental.SceneManagement;
-using UdonSharpEditor;
-#endif
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.SDK3.Components;
+    //using VRC.Udon;
+
+    #if UNITY_EDITOR
+    using UnityEditor;
+    using UnityEditor.Experimental.SceneManagement;
+    using UdonSharpEditor;
+    #endif
+
     [AddComponentMenu("Fukuro Udon/Manual ObjectSync/Manual ObjectSync")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class ManualObjectSync : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/PickupEventTransfer.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/PickupEventTransfer.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+     using UnityEngine;
+     //using VRC.SDKBase;
+     using VRC.Udon;
+     using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/Manual ObjectSync/Pickup Event Transfer")]
     //[RequireComponent(typeof(VRCPickup))]
     [UdonBehaviourSyncMode(BehaviourSyncMode.NoVariableSync)]

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ResetSwitchForObjectSync.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ResetSwitchForObjectSync.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+    using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/Manual ObjectSync/Reset Switch for ObjectSync")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class ResetSwitchForObjectSync : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorProfile.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorProfile.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+    using VRC.SDK3.Components;
+
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class MirrorProfile : UdonSharpBehaviour
     {

--- a/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorProfileChangeSwitch.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorProfileChangeSwitch.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class MirrorProfileChangeSwitch : UdonSharpBehaviour
     {

--- a/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorToggleSwitch.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorToggleSwitch.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+    using VRC.SDK3.Components;
+
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class MirrorToggleSwitch : UdonSharpBehaviour
     {

--- a/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorTuner.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/MirrorTuner/Scripts/MirrorTuner.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+    using VRC.SDK3.Components;
+
     [RequireComponent(typeof(VRCMirrorReflection))]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class MirrorTuner : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/IPlayerAudioRegulator.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/IPlayerAudioRegulator.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     public class IPlayerAudioRegulator : UdonSharpBehaviour
     {
         [Header("Options")]

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PARListController.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PARListController.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     public enum PlayerAudioRegulatorListControllerSwitchMode
     {
         Assign,

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PARSwitchController.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PARSwitchController.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    using VRC.SDK3.Components;
+
     public enum PlayerAudioRegulatorPickupEventType
     {
         None,

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioRegulatorArea.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioRegulatorArea.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/PlayerAudio Master/PA Regulator Area")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class PlayerAudioRegulatorArea : IPlayerAudioRegulator

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioRegulatorList.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioRegulatorList.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/PlayerAudio Master/PA Regulator List")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class PlayerAudioRegulatorList : IPlayerAudioRegulator

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioRegulatorSwitch.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioRegulatorSwitch.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     public enum PlayerAudioRegulatorSwitchMode
     {
         Toggle,

--- a/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioSupervisor.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/PlayerAudioMaster/Scripts/PlayerAudioSupervisor.cs
@@ -1,12 +1,12 @@
 ﻿
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-//using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    //using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/PlayerAudio Master/PA Supervisor")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class PlayerAudioSupervisor : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/Literature.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/Literature.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using UnityEngine.UI;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using UnityEngine.UI;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Smart Slideshow/Literature")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class Literature : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/SSs_Controller.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/SSs_Controller.cs
@@ -4,15 +4,15 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using UnityEngine.UI;
-//using VRC.SDKBase;
-//using VRC.Udon;
-using TMPro;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using UnityEngine.UI;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+    using TMPro;
+
     [AddComponentMenu("Fukuro Udon/Smart Slideshow/Controller")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class SSs_Controller : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/SmartSlideshow.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/SmartSlideshow.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/Smart Slideshow/Smart Slideshow")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class SmartSlideshow : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/WebLiterature.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/SmartSlideshow/Scripts/WebLiterature.cs
@@ -4,15 +4,15 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using UnityEngine.UI;
-using VRC.SDKBase;
-using VRC.Udon.Common.Interfaces;
-using VRC.SDK3.Image;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using UnityEngine.UI;
+    using VRC.SDKBase;
+    using VRC.Udon.Common.Interfaces;
+    using VRC.SDK3.Image;
+
     [AddComponentMenu("Fukuro Udon/Smart Slideshow/Web Literature")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class WebLiterature : Literature

--- a/Packages/com.mimylab.fukuroudon/Runtime/SwivelChair/Scripts/SCKeyInputManager.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/SwivelChair/Scripts/SCKeyInputManager.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-//using VRC.SDKBase;
-//using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    //using VRC.SDKBase;
+    //using VRC.Udon;
+
     [DefaultExecutionOrder(10)]
     [UdonBehaviourSyncMode(BehaviourSyncMode.Manual)]
     public class SCKeyInputManager : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/SwivelChair/Scripts/SwivelChair.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/SwivelChair/Scripts/SwivelChair.cs
@@ -4,18 +4,18 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-//using VRC.Udon;
-using VRC.Udon.Common;
-
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    //using VRC.Udon;
+    using VRC.Udon.Common;
+
+    #if UNITY_EDITOR
+    using UnityEditor;
+    #endif
+
     public enum SwivelChairPlayerPlatform
     {
         PC,

--- a/Packages/com.mimylab.fukuroudon/Runtime/VRFollowHUD/Scripts/LocalPlayerTrackingTracker.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/VRFollowHUD/Scripts/LocalPlayerTrackingTracker.cs
@@ -4,14 +4,14 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-using VRC.SDK3.Components;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+    using VRC.SDK3.Components;
+
     [AddComponentMenu("Fukuro Udon/VR Follow HUD/LocalPlayer Tracking Tracker")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class LocalPlayerTrackingTracker : UdonSharpBehaviour

--- a/Packages/com.mimylab.fukuroudon/Runtime/VRFollowHUD/Scripts/VRFollowHUD.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/VRFollowHUD/Scripts/VRFollowHUD.cs
@@ -4,13 +4,13 @@ Released under the MIT license
 https://opensource.org/licenses/mit-license.php
 */
 
-using UdonSharp;
-using UnityEngine;
-using VRC.SDKBase;
-using VRC.Udon;
-
 namespace MimyLab
 {
+    using UdonSharp;
+    using UnityEngine;
+    using VRC.SDKBase;
+    using VRC.Udon;
+
     [AddComponentMenu("Fukuro Udon/VR Follow HUD/VR Follow HUD")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class VRFollowHUD : LocalPlayerTrackingTracker


### PR DESCRIPTION
UdonSharpコンパイラがすべてのアセンブリをまとめてコンパイルするせいでusingしたクラス名とUsingしてないルート名前空間の要素で名前がかぶるとU# RoslynのCEになるのでその対策です

C#の言語仕様的に、namespace内のusing => その親名前空間の要素(ルート名前空間も含む) => ファイル先頭のusingという解決順番なため、namespace内に入れるとルート名前空間の汚染の影響を受けないです

https://discord.com/channels/737454833258201198/790981512450670632/1171991924970901554
参照