### PR TITLE
Update FukuroUdon.asmdef

### DIFF
--- a/Packages/com.mimylab.fukuroudon/Runtime/FukuroUdon.asmdef
+++ b/Packages/com.mimylab.fukuroudon/Runtime/FukuroUdon.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
FukuroUdon配下のクラス参照を、アセットスクリプトからも可能とします。  

みみー様、大変お世話になっております。素晴らしいスクリプト群の公開、誠にありがとうございます！  
特にManual ObjectSyncを活用させていただいております。  
アセット配下のスクリプトから直接クラスを参照できると尚便利でありがたい！と考え、こちらご提案お送りいたしました。  
採用のご検討いただけましたら幸いです！