### PR TITLE
複数のUdonコンポーネントがついているときもManualObjectSyncのRespawnが呼ばれるようにした

### DIFF
--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ResetSwitchForObjectSync.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ResetSwitchForObjectSync.cs
@@ -25,6 +25,7 @@ namespace MimyLab.FukuroUdon
 
         private float _lastResetTime;
         private VRCObjectSync[] _objectSyncs_vrc;
+        private ManualObjectSync[] _manualObjectSyncs;
         private UdonBehaviour[] _objectSyncs_udon;
 
         private bool _initialized = false;
@@ -33,12 +34,14 @@ namespace MimyLab.FukuroUdon
             if (_initialized) { return; }
 
             _objectSyncs_vrc = new VRCObjectSync[resetObjects.Length];
+            _manualObjectSyncs = new ManualObjectSync[resetObjects.Length];
             _objectSyncs_udon = new UdonBehaviour[resetObjects.Length];
             for (int i = 0; i < resetObjects.Length; i++)
             {
                 if (!resetObjects[i]) { continue; }
 
                 _objectSyncs_vrc[i] = resetObjects[i].GetComponent<VRCObjectSync>();
+                _manualObjectSyncs[i] = resetObjects[i].GetComponent<ManualObjectSync>();
                 _objectSyncs_udon[i] = resetObjects[i].GetComponent<UdonBehaviour>();
             }
 
@@ -73,6 +76,12 @@ namespace MimyLab.FukuroUdon
                 if (_objectSyncs_vrc[i])
                 {
                     _objectSyncs_vrc[i].Respawn();
+                    continue;
+                }
+
+                if (_manualObjectSyncs[i])
+                {
+                    _manualObjectSyncs[i].Respawn();
                     continue;
                 }
 


### PR DESCRIPTION
ResetSwitchForObjectSyncでresetするGameObjectが以下すべてを満たすとき
1. VRCObjectSyncが付いていない
1. ManualObjectSyncがついている
1. 他のUdonコンポーネントがついている

ResetSwitchForObjectSyncのInteractを実行しても 3. のRespawnが実行され 2. のRespawnが実行されないことがあるため、
1 > 2 > 3 の優先度でRespawnを呼ぶようにして実行されるようにした。