### PR TITLE
MOSのRespawn時に確実にpositonとrotationをリセットしたい

### DIFF
--- a/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/DustBoxReturnTrigger.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/GameObjectCeller/Scripts/DustBoxReturnTrigger.cs
@@ -12,7 +12,6 @@ namespace MimyLab.FukuroUdon
     [Icon(ComponentIconPath.FukuroUdon)]
     [AddComponentMenu("Fukuro Udon/GameObject Celler/Dust Box Return Trigger")]
     [RequireComponent(typeof(Collider))]
-    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class DustBoxReturnTrigger : UdonSharpBehaviour
     {
         public GameObject returnTarget = null;

--- a/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
+++ b/Packages/com.mimylab.fukuroudon/Runtime/ManualObjectSync/Scripts/ManualObjectSync.cs
@@ -402,6 +402,7 @@ namespace MimyLab.FukuroUdon
                     _rigidbody.angularVelocity = Vector3.zero;
                     _rigidbody.position = _startPosition;
                     _rigidbody.rotation = _startRotation;
+                    _rigidbody.transform.SetPositionAndRotation(_startPosition, _startRotation);
                 }
                 else
                 {


### PR DESCRIPTION
### ユースケース
持てるコーヒーカップとソーサーのセットをGameObjectCellerで出し入れしたい

### 解決したい点
GameObjectCellerでVRCObjectPoolに以下CoffeeCupSetを登録
- CoffeeCupSet (VRCPickupはつけない)(VRCObjectPoolに登録する)(ActiveRelay to ObjectSyncを付ける)
    - Cup (VRCPickup, Rigidbody, ManualObjectSync) (VRCObjectPoolに登録しない)
    - Saucer (VRCPickup, Rigidbody, ManualObjectSync) (VRCObjectPoolに登録しない)
  
ActiveRelay to ObjectSyncの設定
- EventType=Inactive
- Manual Object Syncs にCupとSaucer 登録
- Is Kinematic = No Change
- Use Gravity = No Change
- Respawn = Invert

このときCupをDustBoxに入れるとCoffeeCupSet がReturnされ、ActiveRelay to ObjectSyncによりCupとSaucerのMOS.Respawn()が呼ばれるが、意図に反して位置がリセットされないため、RespawnするとすぐにDustBoxにまた入れた扱いとなる。

### 修正点
- rigidbodyのpositionとrotationへの変更が効かないケースのようなのでrigidbody.transform.SetPositionAndRotationも実行するようにした。
- ついでにDustBoxReturnTriggerをBehaviourSyncMode.ManualなMOSと併用したいためNone指定を削除